### PR TITLE
adding Lambda role as a CFN resource instead of parameter

### DIFF
--- a/src-cloudformation-iac/studio-classic-to-studio-v2/CreateTestDomainFromSourceDomain.yaml
+++ b/src-cloudformation-iac/studio-classic-to-studio-v2/CreateTestDomainFromSourceDomain.yaml
@@ -10,10 +10,6 @@ Parameters:
     Type: String
     Description: AWS Region for the SageMaker Studio Domain.
   
-  LambdaAdminExecutionRoleArn:
-    Type: String
-    Description: ARN of the Lambda execution role to be used by Lambda to query source domain information.
-  
   TargetDomainName:
     Type: String
     Description: Name of target domain to be created by IaC
@@ -33,12 +29,42 @@ Resources:
             - SageMakerQueryLambda
             - Arn
 
+  SageMakerQueryLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-LambdaExecRole"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: !Sub '${AWS::StackName}-LambdaExecPolicy'
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sagemaker:DescribeDomain
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "*"
+
   SageMakerQueryLambda:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub "${AWS::StackName}-QuerySageMaker"
       Handler: index.lambda_handler
-      Role: !Ref LambdaAdminExecutionRoleArn
+      Role: !GetAtt SageMakerQueryLambdaRole.Arn
       Runtime: python3.11
       MemorySize: 128
       Timeout: 30

--- a/src-cloudformation-iac/studio-classic-to-studio-v2/MigrateSourceDomain.yaml
+++ b/src-cloudformation-iac/studio-classic-to-studio-v2/MigrateSourceDomain.yaml
@@ -9,10 +9,6 @@ Parameters:
   SourceDomainRegion:
     Type: String
     Description: AWS Region for the SageMaker Studio Domain.
-  
-  LambdaAdminExecutionRoleArn:
-    Type: String
-    Description: ARN of the Lambda execution role to be used by Lambda to query source domain information.
 
 Resources:
 
@@ -24,12 +20,43 @@ Resources:
             - SageMakerMigrateLambda
             - Arn
 
+  SageMakerMigrateLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-LambdaExecRole"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: !Sub '${AWS::StackName}-LambdaExecPolicy'
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sagemaker:DescribeDomain
+                  - sagemaker:UpdateDomain
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "*"
+
   SageMakerMigrateLambda:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub "${AWS::StackName}-MigrateStudio"
       Handler: index.lambda_handler
-      Role: !Ref LambdaAdminExecutionRoleArn
+      Role: !GetAtt SageMakerMigrateLambdaRole.Arn
       Runtime: python3.12
       MemorySize: 128
       Timeout: 180


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Updated the CFNs to create a minimum access Lambda role as a resource, instead of getting it as an input parameter


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
